### PR TITLE
Use HousingEditorGetTargetInfo to get furniture ID

### DIFF
--- a/source/HomesteadEngineer/HomesteadEngineer.lua
+++ b/source/HomesteadEngineer/HomesteadEngineer.lua
@@ -15,14 +15,7 @@ function HE.CheckTarget()
       or not HousingEditorCanSelectTargettedFurniture() then
     return nil;
   end
-  LockCameraRotation(true);
-  HousingEditorSelectTargettedFurniture();
-  local furnId=HousingEditorGetSelectedFurnitureId();
-  -- Do this EHT's way to avoid interop issues
-  HousingEditorRequestModeChange(HOUSING_EDITOR_MODE_DISABLED);
-  HousingEditorRequestModeChange(HOUSING_EDITOR_MODE_SELECTION);
-  --HousingEditorRequestSelectedPlacement();
-  LockCameraRotation(false);
+  local furnId, _ = HousingEditorGetTargetInfo();
   return furnId;
 end
 

--- a/source/HomesteadEngineer/HomesteadEngineer.txt
+++ b/source/HomesteadEngineer/HomesteadEngineer.txt
@@ -1,7 +1,7 @@
 ﻿## Title: Homestead Engineer
 ## Description: Place items in your home with precision
-## Version: 0.09.000
-## APIVersion: 100025
+## Version: 0.09.001
+## APIVersion: 101041
 ## Author: WetWired
 ## 
 ## This Add-On is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates. The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries. All rights reserved.


### PR DESCRIPTION
The latest game patch, U41 Scions of Ithelia, seems to have made it so these immediate calls:
```
HousingEditorRequestModeChange(HOUSING_EDITOR_MODE_DISABLED);
HousingEditorRequestModeChange(HOUSING_EDITOR_MODE_SELECTION);
```
don't work so closely after each other, resulting in exiting housing editor mode whenever the user selects the furnishing. This issue can be fixed by using `HousingEditorGetTargetInfo()`, added in U27 Stonethorn, which doesn't require picking up the furnishing to obtain the furnitureId.